### PR TITLE
HSQLDB Dependency Clash

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,10 @@ cache:
 # openjdk9 + oraclejdk10 were both removed from Ubuntu
 language: java
 jdk:
+  - openjdk11
   - openjdk10
   - openjdk8
-  - oraclejdk8
+#  - oraclejdk8
 
 #matrix:
 #  allow_failures:

--- a/build.gradle
+++ b/build.gradle
@@ -29,11 +29,9 @@ repositories {
 
 
 dependencies {
-//  implementation 'au.com.bytecode:opencsv:2.4' // was 2.3
     implementation 'ch.ethz.ganymed:ganymed-ssh2:262'
     implementation 'com.google.guava:guava:26.0-jre'
     implementation 'com.googlecode.log4jdbc:log4jdbc:1.2'
-//  implementation 'com.h2database:h2:1.3.161'
     implementation 'com.sun.xml.bind:jaxb-core:2.3.0'
     implementation 'com.sun.xml.bind:jaxb-impl:2.3.0'
     implementation 'commons-cli:commons-cli:1.2'
@@ -48,7 +46,6 @@ dependencies {
     implementation 'javax.persistence:persistence-api:1.0'
     implementation 'javax.xml.bind:jaxb-api:2.3.0'
     implementation 'log4j:log4j:1.2.17'
-//  implementation 'monetdb:monetdb-jdbc:2.9'
     implementation 'mysql:mysql-connector-java:5.1.47'
     implementation 'net.sf.opencsv:opencsv:2.3'
     implementation 'net.sourceforge.collections:collections-generic:4.01'
@@ -57,7 +54,9 @@ dependencies {
     implementation 'org.apache.httpcomponents:httpclient:4.3.6'
     implementation 'org.apache.httpcomponents:httpcore:4.3.3'
     implementation 'org.apache.httpcomponents:httpmime:4.3.6'
-    implementation 'org.apache.openjpa:openjpa-persistence-jdbc:1.0.4'
+    implementation('org.apache.openjpa:openjpa-persistence-jdbc:1.0.4') {
+        exclude group: 'hsqldb', module: 'hsqldb'
+    }
     implementation 'org.eclipse.persistence:javax.persistence:2.0.5'
     implementation 'org.eclipse.persistence:org.eclipse.persistence.jpa:2.4.2'
     implementation 'org.hibernate.javax.persistence:hibernate-jpa-2.0-api:1.0.1.Final'
@@ -67,8 +66,7 @@ dependencies {
     implementation 'org.hsqldb:hsqldb:2.5.0'
     implementation 'org.postgresql:postgresql:9.4.1209.jre6'
     implementation 'org.slf4j:slf4j-simple:1.7.5'
-    implementation 'org.xerial:sqlite-jdbc:3.7.2' // was 3.6.20.1, but that's not in central.
-//  implementation 'javax.jdo:jdo2-api:2.3-eb'
+    implementation 'org.xerial:sqlite-jdbc:3.7.2'
 
     implementation 'org.polypheny:polypheny-jdbc-driver:1.3'
 


### PR DESCRIPTION
Fixes the HSQLDB dependency clash by excluding the transitive HSQLDB dependency of org.apache.openjpa