### PR TITLE
TPC-C for current Polypheny-FRAM - Episode 2

### DIFF
--- a/config/polypheny/tpcc.xml
+++ b/config/polypheny/tpcc.xml
@@ -20,7 +20,8 @@
             <serial>false</serial>
             <time>10</time>
             <rate>10000</rate>
-            <weights>45,43,4,4,4</weights>
+            <!--<weights>45,43,4,4,4</weights>-->
+            <weights>46,44,5,5<!--,0--></weights>
         </work>
     </works>
 
@@ -38,8 +39,8 @@
         <transactiontype>
             <name>Delivery</name>
         </transactiontype>
-        <transactiontype>
+        <!--<transactiontype>
             <name>StockLevel</name>
-        </transactiontype>
+        </transactiontype>-->
     </transactiontypes>
 </parameters>

--- a/src/com/oltpbenchmark/benchmarks/tpcc/dialects/polypheny-dialects.xml
+++ b/src/com/oltpbenchmark/benchmarks/tpcc/dialects/polypheny-dialects.xml
@@ -1,17 +1,23 @@
 <?xml version="1.0"?>
 <dialects>
     <dialect type="POLYPHENY">
-        <procedure name="NewOrder">
-            <statement name="stmtGetDistSQL"><!-- FOR UPDATE -->
-                SELECT D_NEXT_O_ID, D_TAX
-                FROM DISTRICT
-                WHERE D_W_ID = ? AND D_ID = ?
+        <procedure name="Delivery">
+            <statement name="delivGetOrderIdSQL"><!-- Replace `ORDER BY NO_O_ID ASC LIMIT 1` with `MIN(NO_O_ID) AS NO_O_ID` -->
+                SELECT MIN(NO_O_ID) AS NO_O_ID
+                FROM   NEW_ORDER
+                WHERE  NO_D_ID = ? AND NO_W_ID = ?
             </statement>
-            <statement name="stmtGetStockSQL"><!-- FOR UPDATE -->
-                SELECT S_QUANTITY, S_DATA, S_DIST_01, S_DIST_02, S_DIST_03, S_DIST_04,
-                S_DIST_05, S_DIST_06, S_DIST_07, S_DIST_08, S_DIST_09, S_DIST_10
-                FROM STOCK
-                WHERE S_I_ID = ? AND S_W_ID = ?
+        </procedure>
+        <procedure name="NewOrder">
+            <statement name="stmtGetDistSQL"><!-- `FOR UPDATE` is not supported -->
+                SELECT D_NEXT_O_ID, D_TAX
+                FROM   DISTRICT
+                WHERE  D_W_ID = ? AND D_ID = ?
+            </statement>
+            <statement name="stmtGetStockSQL"><!-- `FOR UPDATE` is not supported -->
+                SELECT S_QUANTITY, S_DATA, S_DIST_01, S_DIST_02, S_DIST_03, S_DIST_04, S_DIST_05, S_DIST_06, S_DIST_07, S_DIST_08, S_DIST_09, S_DIST_10
+                FROM   STOCK
+                WHERE  S_I_ID = ? AND S_W_ID = ?
             </statement>
         </procedure>
     </dialect>


### PR DESCRIPTION
Rewriting the "Delivery-Get-OrderID" statement to use `MIN` instead of `ORDER BY ASC` with `LIMIT 1`.

The current version of Polypheny-FRAM cannot guarantee the correct processing of `ORDER BY`. Thus, the additionally prefered `MIN` function replaces the original construct.